### PR TITLE
improved hint for setting PATH

### DIFF
--- a/GHC/GHC/GHCAppDelegate.m
+++ b/GHC/GHC/GHCAppDelegate.m
@@ -24,10 +24,11 @@
     self.haskellIcon.imageFrameStyle = NSImageFrameNone;
     self.haskellIcon.image = [NSApp applicationIconImage];
     self.shellCopy.stringValue = [NSString stringWithFormat:
-                                  @"# Add this to your .bashrc\n"
-                                  @"GHC_APP=\"%@\"\n"
-                                  @"export PATH=\"${HOME}/.cabal/bin:${GHC_APP}/bin:${PATH}\"\n"
-                                  @"", contents];
+                                  @"# Add this to your ~/.bashrc and ~/.profile files\n"
+                                  @"if [ -z \"$GHC_DOT_APP\" ]; then\n"
+                                  @"    export GHC_DOT_APP=\"%@\"\n"
+                                  @"    export PATH=\"${HOME}/.cabal/bin:${GHC_DOT_APP}/bin:${PATH}\"\n"
+                                  @"fi\n", contents];
 }
 
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)app


### PR DESCRIPTION
On OsX the terminal starts login shell sessions. Expert users may have
already personalized the bash configuration, and they will know what to
do. Non experts should be directed to create both login and non login bash
configuration files (but not forced into creating a login configuration file that
sources the non login ones: when they become experts they’ll know if
they want to do it and how).
